### PR TITLE
Values might be better as semicolon-delimited text.

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -71,7 +71,7 @@ The "Client-Hints" Request Header Field
 
 The "Client-Hints" request header field describes the current client preferences that the server can use to adapt and optimize the resource to satisfy a given request.
 
-The Client-Hints field-value is a comma-delimited list of header fields. The  field-name values are case insensitive.
+The Client-Hints field-value is a semicolon-delimited list of header fields. The field-name values are case insensitive.
 
 
 Client-Hints Header Fields


### PR DESCRIPTION
RFC2616, section 4.2 specifies that HTTP headers appearing multiple
times can be combined with a comma. Both WebKit and Mozilla respect
this, which means that commas ought to be avoided in the text of the
header's value. This patch suggests a semicolon as a reasonable
alternative.
