### PR TITLE
Make definition of 'dh' hint clearer

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -104,7 +104,7 @@ This document defines the following hint names:
 
 ### dh
 
-- Description: device-width in secondary orientation, in density independent pixels.
+- Description: device-height in primary orientation, in density independent pixels (device-width in secondary orientation).
 - Value Type: number
 
 ### dw


### PR DESCRIPTION
_Primary_ function of the 'dh' hint is to describe the device-height, which then equals the device-width in secondary orientation.
