### PR TITLE
Opt-in should not apply to main document request

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Current list includes `DPR` (device pixel ratio), `RW` (resource width), and `MD
 _Note: have a proposal for another hint? Open an issue, document your use case._ 
 
 ### Opt-in hint delivery
-For the main document request, all user agent supported hints should be sent to the server. 
-That is in order to support use-cases where server-side processing requires HTML manipulations.
+For the main document request, some user agent supported hints, and specifically the 'RW' hint, should be sent to the server. 
+That is in order to support use-cases where server-side processing requires HTML manipulations, such as the [RESS](http://www.lukew.com/ff/entry.asp?1392) technique.
 
 For other resources, in order to reduce request overhead the hints can be sent based on opt-in basis. Therefore, the user agent may refrain from sending hints over sub-resource requests, unless the server advertises support for these hints. See <a href="http://igrigorik.github.io/http-client-hints/#rfc.section.2.3.1">Advertising Support for Client Hints</a> for more details. 
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Current list includes `DPR` (device pixel ratio), `RW` (resource width), and `MD
 _Note: have a proposal for another hint? Open an issue, document your use case._ 
 
 ### Opt-in hint delivery
-To reduce request overhead the hints are sent based on opt-in basis: the server advertises supported hints, the user agent sends the appropriate hint request headers for subsequent requests - see <a href="http://igrigorik.github.io/http-client-hints/#rfc.section.2.3.1">Advertising Support for Client Hints</a>. 
+For the main document request, all user agent supported hints should be sent to the server. 
+That is in order to support use-cases where server-side processing requires HTML manipulations.
 
-Note that this means that the user agent will not send hints on the very first request. However, if the site provides correct opt-in information in the response, hints will be delivered by all subsequent requests. Also, the user agent may remember site opt-in across browsing sessions, enabling hint delivery of all subsequent requests.
-
+For other resources, in order to reduce request overhead the hints can be sent based on opt-in basis. Therefore, the user agent may refrain from sending hints over sub-resource requests, unless the server advertises support for these hints. See <a href="http://igrigorik.github.io/http-client-hints/#rfc.section.2.3.1">Advertising Support for Client Hints</a> for more details. 
 
 ### Use cases 
 #### Responsive Design + Server Side Components (RESS)

--- a/draft.md
+++ b/draft.md
@@ -75,7 +75,7 @@ Clients control which Client Hint headers and their respective header fields are
 
 The client and server, or an intermediate proxy, may use an opt-in mechanism to negotiate which fields should be reported to allow for efficient content adaption.
 
-In order to support use-cases where server-side processing requires HTML manipulations, clients SHOULD send hints along with the initial main document request.
+In order to support use-cases where server-side processing requires HTML manipulations, clients SHOULD send the 'RW' hint along with the initial main document request.
 
 ## Server Processing of Client Hints
 

--- a/draft.md
+++ b/draft.md
@@ -75,6 +75,7 @@ Clients control which Client Hint headers and their respective header fields are
 
 The client and server, or an intermediate proxy, may use an opt-in mechanism to negotiate which fields should be reported to allow for efficient content adaption.
 
+In order to support use-cases where server-side processing requires HTML manipulations, clients SHOULD send hints along with the initial main document request.
 
 ## Server Processing of Client Hints
 
@@ -97,6 +98,8 @@ For example:
 
 When a client receives Accept-CH, it SHOULD append the Client Hint headers that match the advertised field-values. For example, based on Accept-CH example above, the client would append DPR, RW, and MD headers to all subsequent requests.
 
+_Issue: Does the opt-in mechanism apply to third-party resources on the
+same page? iframes?_
 
 ### Interaction with Caches
 


### PR DESCRIPTION
Following the discussions at EdgeConf, and in order to enable CH-based HTML manipulations (which hopefully can reduce/eliminate the use of UA sniffing), I'm taking a stab at adding text that makes it a SHOULD for UAs to send all hints on the first request, but lets them make the hints opt-in for subsequent requests.
