### PR TITLE
Save-Data: client preference for reduced data usage

### DIFF
--- a/draft.md
+++ b/draft.md
@@ -196,6 +196,17 @@ The "Downlink" header field is a number that, in requests, indicates the client'
 If Downlink occurs in a message more than once, the minimum value should be used to override other occurrences.
 
 
+# The Save-Data Hint
+
+The "Save-Data" header field is a boolean that, in requests, indicates client's preference for reduced data usage, due to high transfer costs, slow connection speeds, or other reasons.
+
+~~~
+  Save-Data = 1
+~~~
+
+The boolean is a signal indicating explicit user opt-in into a reduced data usage mode on the client, and when communicated to origins allows them to deliver alternate content honoring such preference - e.g. smaller image and video resources, alternate markup, and so on. 
+
+
 # Examples
 
 For example, given the following request headers:
@@ -272,6 +283,13 @@ This document defines the "Accept-CH", "DPR", "Width", and "Downlink" HTTP reque
 - Related information: for Client Hints
 
 - Header field name: Accept-CH
+- Applicable protocol: HTTP
+- Status: standard
+- Author/Change controller: Ilya Grigorik, ilya@igvita.com
+- Specification document(s): [this document]
+- Related information: for Client Hints
+
+- Header field name: Save-Data
 - Applicable protocol: HTTP
 - Status: standard
 - Author/Change controller: Ilya Grigorik, ilya@igvita.com


### PR DESCRIPTION
For many users, internet access is slow and expensive. To reduce costs many users opt-in to use optimization services (proxies) that fetch and optimize resources on their behalf - e.g. re-encode images at lower quality, compress text resources, etc. However, this model has several limitations: 

* Proxies cease to function when user is accessing content over HTTPS.
* Origin sites (accessed over HTTP and HTTPS) may be willing to help provide an improved “save data” experience but don't have a reliable and well defined way to detect such user preference.

The “Save-Data” request header is an end-to-end header that addresses both of the above limitations: it is advertised by the browser based on user opt-in, and it is sent to all origins. The presence of the header is an indicate of explicit user opt-in into a "reduced data usage" mode.

_Note: the fact that Save-Data is an indication of explicit user opt-in is important. This allows the user to opt-out from such experience - e.g. user may be on slow or expensive network but may still want to fetch high resolution images for one reason or another._

---

An example implementation in Google Chrome:
- `Save-Data` header is appended to all requests when user enables Chrome Data Compression.
- `Save-Data` request header is end-to-end: requests that pass through Chrome Data Compression proxy pass through the header, allowing the site to optimize the experience at the origin.
- `Save-Data` header _does not_ communicate anything about the "quality levels" of certain content types (e.g. images), or similar preferences. It _may_ be useful to communicate that information as well, but that should be done via separate mechanism (e.g. other headers).