### PR TITLE
update Width to report in physical pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This specification defines a set of HTTP request header fields, colloquially kno
 ---
 
 ### Available hints
-Current list includes `DPR` (device pixel ratio), `Width` (display width), `Viewport-Width`, and `Downlink` (maximum downlink speed) request headers, and `Content-DPR` response header that is used to confirm the DPR of selected image resources - see full definitions in <a href="http://igrigorik.github.io/http-client-hints/">latest spec</a>.
+Current list includes `DPR` (device pixel ratio), `Width` (resource width), `Viewport-Width` (layout viewport width), and `Downlink` (maximum downlink speed) request headers, and `Content-DPR` response header that is used to confirm the DPR of selected image resources - see full definitions in <a href="http://igrigorik.github.io/http-client-hints/">latest spec</a>.
 
 _Note: have a proposal for another hint? Open an issue, document your use case._
 
@@ -84,14 +84,14 @@ GET /img.jpg HTTP/1.1
 User-Agent: Awesome Browser
 Accept: image/webp, image/jpg
 DPR: 2.0
-Width: 160
+Width: 320
 ```
 ```http
 HTTP/1.1 200 OK
 Server: Awesome Server
 Content-Type: image/jpg
 Content-Length: 124523
-Vary: DPR, Width
+Vary: Width
 Content-DPR: 2.0
 
 (image data)
@@ -102,7 +102,7 @@ In the above example, the user agent advertises its device pixel ratio and image
 * The server can scale the asset to requested width, or return the closest available match to help reduce number of transfered bytes.
 * The server can factor in the device pixel ratio of the device in its selection algorithm.
 
-Note that the display width of the image may not be available at request time, in which case the user agent would omit the `Width` hint. Also, the exact logic as to which asset is selected is deferred to the server, which can optimize its selection based on available resources, cache hit rates, and other criteria.
+Note that the width of the image may not be available at request time, in which case the user agent would omit the `Width` hint. Also, the exact logic as to which asset is selected is deferred to the server, which can optimize its selection based on available resources, cache hit rates, and other criteria.
 
 
 #### `<picture>` element
@@ -157,7 +157,7 @@ The combination of `DPR` and `Width` hints also simplifies delivery of variable 
 ```
 
 * Device pixel ratio is communicated via the `DPR` request header
-* The `vw` size is converted to CSS `px` size based on client's layout viewport size and the resulting value is communicated via the `Width` request header
+* The `vw` size is converted to physical `px` size based on client's layout viewport size and the resulting value is communicated via the `Width` request header
 * The server computes the optimal image variant based on communicated `DPR` and `Width` values and responds with the optimal image variant.
 
 HTTP negotiation flow for the example above:
@@ -165,13 +165,11 @@ HTTP negotiation flow for the example above:
 ```
 > GET /wolf.jpg HTTP/1.1
 > DPR: 2.0
-> Width: 400
-
-(Server: 2x DPR * 400 CSS px = 800px -> selects wolf-800.jpg or performs a resize)
+> Width: 800
 
 < 200 OK
 < Content-DPR: 2.0
-< Vary: DPR, Width
+< Vary: Width
 < ...
 ```
 
@@ -217,7 +215,7 @@ Image bytes: 9998
 # Request 100 CSS px wide asset with DPR of 1.5
 $> curl -s http://app.resrc.it/http://www.resrc.it/img/demo/preferred.jpg \
   -o /dev/null -w "Image bytes: %{size_download}\n" \
-  -H "DPR: 1.5" -H "Width: 100"
+  -H "DPR: 1.5" -H "Width: 150"
 Image bytes: 17667
 
 # Request 200 CSS px wide asset with DPR of 1.0

--- a/browser_implementation_considerations.md
+++ b/browser_implementation_considerations.md
@@ -9,7 +9,7 @@ The Client Hints specification is intended for a wide audience, and does not spe
 
 ## `Width`
 
-The [`Width` request header][width] is sent by the client and indicates the layout width of an HTMLImageElement in CSS pixels.
+The [`Width` request header][width] is sent by the client and indicates the  width of an HTMLImageElement in physical pixels - i.e. same value as provided by the [w descriptor](https://html.spec.whatwg.org/multipage/embedded-content.html#introduction-3:viewport-based-selection-2) for viewport-based selection.
 
 User agents request images long before page layout occurs.
 For this reason, the `Width` hint can only be sent by user agents when the layout width of the image is indicated in markup, via the `sizes` attributes.

--- a/draft.md
+++ b/draft.md
@@ -165,7 +165,7 @@ If Content-DPR occurs in a message more than once, the last value overrides all 
 
 # The Width Client Hint
 
-The "Width" header field is a number that, in requests, indicates the resource width in CSS px (e.g. display width of an image). The provided CSS px value is a number rounded to the largest smallest following integer (i.e. ceiling value).
+The "Width" header field is a number that, in requests, indicates the resource width in physical px (i.e. intrinsic size of an image). The provided physical px value is a number rounded to the largest smallest following integer (i.e. ceiling value).
 
 ~~~
   Width = 1*DIGIT
@@ -213,11 +213,11 @@ For example, given the following request headers:
 
 ~~~
   DPR: 2.0
-  Width: 160
+  Width: 320
   Viewport-Width: 320
 ~~~
 
-The server knows that the device pixel ratio is 2.0, that the intended display width of requested resource is 160 CSS px, and that the viewport width is 320 CSS px.
+The server knows that the device pixel ratio is 2.0, that the intended display width of requested resource is 160 CSS px (320 physical pixels at 2x resolution), and that the viewport width is 320 CSS px.
 
 If the server uses above hints to perform resource selection for an image asset, it must confirm its selection via the Content-DPR response header to allow the client to calculate the appropriate intrinsic size of the image response. The server does not need to confirm resource width, only the ratio between physical pixels and CSS px of the selected image resource:
 


### PR DESCRIPTION
We originally defined `Width` to report in CSS px because the same header was responsible for reporting both the "intended image display width", or the "layout viewport size" for resources that don't have a "display width". However, we've since split these use cases (see https://github.com/igrigorik/http-client-hints/pull/48) into separate headers: `Viewport-Width` and `Width`.

This update changes the definition of `Width` to report image display width (when it's known) in physical pixels, instead of CSS pixels. This offers a couple of important benefits:

```html
<img srcset="wolf-480.jpg 480w, ..., wolf-1920.jpg 1920w" sizes="...">
```

1. The communicated value is aligned with `w descriptor` used for [viewport-based selection](https://html.spec.whatwg.org/multipage/embedded-content.html#introduction-3:viewport-based-selection-2).
1. The communicated value significantly improves interaction with HTTP caches:
  * With current definition the cache has to vary the response based on DPR and Width (i.e. `Vary: DPR, Width`) which leads to unnecessary fragmentation (see https://github.com/igrigorik/http-client-hints/issues/59).
  * With updated definition the cache would have to vary on Width only.

Closes #59.




