### PR TITLE
Change Viewport-Width from CSS pixels to physical pixels

### DIFF
--- a/browser_implementation_considerations.md
+++ b/browser_implementation_considerations.md
@@ -51,7 +51,8 @@ TODO: Turn this into normative text.
 
 ## Viewport-Width
 
-The `Viewport-Width` value should be the size of the [initial containing block](http://www.w3.org/TR/CSS21/visudet.html#containing-block-details) in CSS pixels.
+The `Viewport-Width` value should be the size of the [initial containing block](http://www.w3.org/TR/CSS21/visudet.html#containing-block-details) in physical pixels,
+so the size of the initial containing block in CSS pixels multiplied by the DPR.
 When the height or width of the initial containing block is changed, the value sent for consecutive requests should be scaled accordingly.
 
 _Note:_ The initial containing block's size is affected

--- a/draft.md
+++ b/draft.md
@@ -160,7 +160,7 @@ DPR ratio affects the calculation of intrinsic size of image resources on the cl
 
 Note that DPR confirmation is only required for image responses, and the server does not need to confirm the resource width as this value can be derived from the resource itself once it is decoded by the client.
 
-If Content-DPR occurs in a message more than once, the last value overrides all previous occurrences. 
+If Content-DPR occurs in a message more than once, the last value overrides all previous occurrences.
 
 
 # The Width Client Hint
@@ -176,13 +176,13 @@ If the resource width is not known at the time of the request or the resource do
 
 # The Viewport-Width Client Hint
 
-The "Viewport-Width" header field is a number that, in requests, indicates the layout viewport width in CSS px. The provided CSS px value is a number rounded to the largest smallest following integer (i.e. ceiling value).
+The "Viewport-Width" header field is a number that, in requests, indicates the layout viewport width in physical px (i.e. layout width in CSS px multiplied by DPR). The provided physical px value is a number rounded to the largest smallest following integer (i.e. ceiling value).
 
 ~~~
   Viewport-Width = 1*DIGIT
 ~~~
 
-If Viewport-Width occurs in a message more than once, the last value overrides all previous occurrences. 
+If Viewport-Width occurs in a message more than once, the last value overrides all previous occurrences.
 
 
 # The Downlink Client Hint


### PR DESCRIPTION
As pointed out by @foolip on the [blink-dev thread](https://discourse.wicg.io/t/fallback-for-when-external-script-times-out/1090/11), it makes sense to also define `Viewport-Width` with physical pixel units.

That would help to avoid confusion around pixel units of the different CH headers, as well as benefit `Viewport-Width` based resource cacheability, in the same way moving to physical pixels benefits `Width`.